### PR TITLE
Handle page content extraction failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,6 @@ project and adjust the `php` binary if necessary:
 
 `process_queue_cli.php` checks whether there are any tasks waiting and exits
 immediately when the queue is empty to minimize server load.
+
+The page content processor will also mark a task item as failed when no text can
+be extracted from the provided URL.

--- a/fetch_page_content.php
+++ b/fetch_page_content.php
@@ -51,7 +51,12 @@ function fetchPageContent($url) {
         
         // Wyczyść treść HTML
         $cleaned_content = cleanHtmlContent($html);
-        
+
+        if (strlen(trim($cleaned_content)) === 0) {
+            error_log("No text extracted from URL: $url");
+            return "No text extracted from URL";
+        }
+
         return $cleaned_content;
         
     } catch (Exception $e) {

--- a/process_page_content.php
+++ b/process_page_content.php
@@ -123,8 +123,17 @@ try {
             try {
                 $page_content = fetchAndSavePageContent($pdo, $item['id'], $item['url']);
                 
-                if (strpos($page_content, 'Nie udało się pobrać') === 0 || strpos($page_content, 'Błąd') === 0) {
-                    logPageContentMessage("Failed to fetch content for {$item['url']}: $page_content", 'error');
+                if (
+                    strpos($page_content, 'Nie udało się pobrać') === 0 ||
+                    strpos($page_content, 'Błąd') === 0 ||
+                    strpos($page_content, 'No text extracted from URL') === 0 ||
+                    strlen(trim($page_content)) === 0
+                ) {
+                    if (strlen(trim($page_content)) === 0 || strpos($page_content, 'No text extracted from URL') === 0) {
+                        logPageContentMessage("No text extracted from {$item['url']}", 'error');
+                    } else {
+                        logPageContentMessage("Failed to fetch content for {$item['url']}: $page_content", 'error');
+                    }
                     
                     // Oznacz element jako failed
                     $stmt = $pdo->prepare("UPDATE task_items SET status = 'failed' WHERE id = ?");


### PR DESCRIPTION
## Summary
- detect empty cleaned page content in `fetch_page_content.php`
- mark items failed in `process_page_content.php` when no text is extracted
- document behavior in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685a582a17a08333be9657771b68b088