### PR TITLE
Remember previous text between categories

### DIFF
--- a/install.php
+++ b/install.php
@@ -90,6 +90,7 @@ if ($_POST) {
             status ENUM('pending', 'processing', 'completed', 'failed', 'partial_failure') DEFAULT 'pending',
             strictness_level DECIMAL(2,1) DEFAULT 0.0,
             task_data LONGTEXT,
+            last_generated_text LONGTEXT,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
             FOREIGN KEY (content_type_id) REFERENCES content_types(id),

--- a/process_queue.php
+++ b/process_queue.php
@@ -312,7 +312,7 @@ function processTaskItem($pdo, $queue_item, $api_keys) {
     
     // Pobierz dane zadania
     $stmt = $pdo->prepare(
-        "SELECT ti.*, t.strictness_level, ct.id as content_type_id, ct.requires_verification,
+        "SELECT ti.*, t.strictness_level, t.task_data, t.last_generated_text, ct.id as content_type_id, ct.requires_verification,
                 am.provider, am.model_slug
          FROM task_items ti
          JOIN tasks t ON ti.task_id = t.id
@@ -369,12 +369,25 @@ function processTaskItem($pdo, $queue_item, $api_keys) {
         throw new Exception("Invalid JSON input_data for task item ID: {$task_item_id} - " . json_last_error_msg());
     }
 
+    $task_options = [];
+    if (!empty($task_item['task_data'])) {
+        $task_options = json_decode($task_item['task_data'], true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new Exception("Invalid JSON task_data for task ID: {$task_item['task_id']} - " . json_last_error_msg());
+        }
+    }
+
+    $similar_categories = !empty($task_options['similar_categories']);
+
     logMessage("Input data for ID {$task_item_id}: " . json_encode($input_data));
-    
+
     // Przygotuj dane do zamiany w promptach
     $replacements = $input_data;
     $replacements['strictness_level'] = $task_item['strictness_level'];
     $replacements['page_content'] = $task_item['page_content'];
+    if ($similar_categories && !empty($task_item['last_generated_text'])) {
+        $replacements['previous_text'] = $task_item['last_generated_text'];
+    }
     
     // Zamień zmienne w promptcie generowania
     $generate_prompt = replacePromptPlaceholders($generate_prompt_template, $replacements);
@@ -455,10 +468,14 @@ function processTaskItem($pdo, $queue_item, $api_keys) {
         status = VALUES(status)
     ");
     $stmt->execute([$task_item_id, $generated_text, $verified_text]);
-    
+
     logMessage("Content generated and saved for ID {$task_item_id}");
     logMessage("Generated text preview: " . substr($generated_text, 0, 100) . "...");
     logMessage("Verified text preview: " . substr($verified_text, 0, 100) . "...");
+
+    // Update last generated text for the task
+    $stmt = $pdo->prepare("UPDATE tasks SET last_generated_text = ? WHERE id = ?");
+    $stmt->execute([$verified_text, $task_item['task_id']]);
 }
 
 /**

--- a/update.php
+++ b/update.php
@@ -1,0 +1,19 @@
+<?php
+require_once 'auth_check.php';
+requireAdmin();
+
+$pdo = getDbConnection();
+
+try {
+    // Check if the column already exists
+    $stmt = $pdo->query("SHOW COLUMNS FROM tasks LIKE 'last_generated_text'");
+    if (!$stmt->fetch()) {
+        $pdo->exec("ALTER TABLE tasks ADD COLUMN last_generated_text LONGTEXT NULL AFTER task_data");
+        echo "Added last_generated_text column to tasks table.";
+    } else {
+        echo "last_generated_text column already exists.";
+    }
+} catch (Exception $e) {
+    echo 'Update failed: ' . $e->getMessage();
+}
+?>


### PR DESCRIPTION
## Summary
- add `similar_categories` checkbox to new task form
- persist flag in task_data on create
- extend install and new update script to add `last_generated_text` column
- include previous text in generation when enabled
- record last generated text for next item

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_685ba92fa16c8333917fa637b6689e14