### PR TITLE
Add database update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ ALTER DATABASE <db_name> CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 ALTER TABLE <table_name> CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ```
 
+## Database updates
+
+When upgrading an existing installation, run the update script to add any
+columns introduced in later versions. Execute the following command from the
+project root:
+
+```bash
+php update.php
+```
+
+The script checks for the `task_items.previous_text` and
+`tasks.last_generated_text` columns and creates them if they are missing.
+
 ## Node dependencies and linting
 
 Install the Node packages defined in `package.json` before running the lint

--- a/update.php
+++ b/update.php
@@ -1,19 +1,44 @@
+#!/usr/bin/env php
 <?php
-require_once 'auth_check.php';
-requireAdmin();
+// Script for updating the database schema
 
-$pdo = getDbConnection();
+if (php_sapi_name() !== 'cli') {
+    http_response_code(403);
+    die('This script can only be run from command line.');
+}
+
+$app_root = dirname(__FILE__);
+chdir($app_root);
+
+if (!file_exists($app_root . '/config.php')) {
+    echo "ERROR: Configuration file not found at: " . $app_root . "/config.php\n";
+    exit(1);
+}
+
+require_once $app_root . '/config.php';
 
 try {
-    // Check if the column already exists
+    $pdo = getDbConnection();
+
+    // Check task_items.previous_text
+    $stmt = $pdo->query("SHOW COLUMNS FROM task_items LIKE 'previous_text'");
+    if (!$stmt->fetch()) {
+        $pdo->exec("ALTER TABLE task_items ADD COLUMN previous_text TEXT NULL");
+        echo "Added previous_text column to task_items.\n";
+    } else {
+        echo "task_items.previous_text already exists.\n";
+    }
+
+    // Check tasks.last_generated_text
     $stmt = $pdo->query("SHOW COLUMNS FROM tasks LIKE 'last_generated_text'");
     if (!$stmt->fetch()) {
         $pdo->exec("ALTER TABLE tasks ADD COLUMN last_generated_text LONGTEXT NULL AFTER task_data");
-        echo "Added last_generated_text column to tasks table.";
+        echo "Added last_generated_text column to tasks.\n";
     } else {
-        echo "last_generated_text column already exists.";
+        echo "tasks.last_generated_text already exists.\n";
     }
 } catch (Exception $e) {
-    echo 'Update failed: ' . $e->getMessage();
+    echo 'Update failed: ' . $e->getMessage() . "\n";
+    exit(1);
 }
-?>
+


### PR DESCRIPTION
## Summary
- add CLI `update.php` to maintain schema compatibility
- document running the script for upgrades in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685bac73b5fc8333860bb4c6c12fff21