### PR TITLE
Allow update script to run via browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ ALTER TABLE <table_name> CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicod
 
 ## Database updates
 
-When upgrading an existing installation, run the update script to add any
-columns introduced in later versions. Execute the following command from the
-project root:
+When upgrading an existing installation, use the `update.php` script to add any
+columns introduced in later versions. You can either run it from the command
+line or open it directly in your browser. For CLI usage execute:
 
 ```bash
 php update.php

--- a/update.php
+++ b/update.php
@@ -2,9 +2,9 @@
 <?php
 // Script for updating the database schema
 
-if (php_sapi_name() !== 'cli') {
-    http_response_code(403);
-    die('This script can only be run from command line.');
+$is_cli_mode = php_sapi_name() === 'cli';
+if (!$is_cli_mode) {
+    header('Content-Type: text/plain; charset=utf-8');
 }
 
 $app_root = dirname(__FILE__);


### PR DESCRIPTION
## Summary
- remove CLI-only restriction from `update.php`
- document that `update.php` can be run from the command line or a browser

## Testing
- `git show -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685ba6a50500833388894ec16a73ded5