### PR TITLE
Fix previous text handling in process queue

### DIFF
--- a/process_queue.php
+++ b/process_queue.php
@@ -385,10 +385,16 @@ function processTaskItem($pdo, $queue_item, $api_keys) {
     $replacements = $input_data;
     $replacements['strictness_level'] = $task_item['strictness_level'];
     $replacements['page_content'] = $task_item['page_content'];
+
+    $previous = null;
     if ($similar_categories && !empty($task_item['last_generated_text'])) {
-        $replacements['previous_text'] = $task_item['last_generated_text'];
+        $previous = $task_item['last_generated_text'];
+    }
     if (!empty($task_item['previous_text'])) {
-        $replacements['previous_text'] = $task_item['previous_text'];
+        $previous = $task_item['previous_text'];
+    }
+    if ($previous) {
+        $replacements['previous_text'] = $previous;
         $generate_prompt_template .= "\n\nRewrite the text in a different style than the provided previous version.";
     }
     


### PR DESCRIPTION
## Summary
- fix missing bracket in `process_queue.php`
- handle previous text logic using a single `$previous` variable
- append rewrite instruction when previous text is present

## Testing
- `php -l process_queue.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb61931dc8333b31d239adc623fae