### PR TITLE
Use PHP_BINARY when launching queue processor

### DIFF
--- a/process_queue_cli.php
+++ b/process_queue_cli.php
@@ -90,7 +90,8 @@ try {
     $output = [];
     $return_code = 0;
     
-    $command = "/usr/bin/php " . escapeshellarg($app_root . "/process_queue.php") . " 2>&1";
+    // Użyj tego samego interpretera PHP, który uruchomił ten skrypt
+    $command = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($app_root . "/process_queue.php") . " 2>&1";
     exec($command, $output, $return_code);
     
     // Zaloguj wynik


### PR DESCRIPTION
## Summary
- call `process_queue.php` with the same PHP interpreter used to run the CLI script

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d2ed7d22c8333bf8b63872a2dc84f