### PR TITLE
Add admin page content viewer

### DIFF
--- a/admin_queue.php
+++ b/admin_queue.php
@@ -228,6 +228,7 @@ $queue_items = $stmt->fetchAll();
                                             <th>Projekt</th>
                                             <th>Zadanie</th>
                                             <th>URL</th>
+                                            <th>Treść</th>
                                             <th>Status</th>
                                             <th>Priorytet</th>
                                             <th>Próby</th>
@@ -247,6 +248,11 @@ $queue_items = $stmt->fetchAll();
                                                     <div style="max-width: 150px; word-break: break-all; font-size: 0.8em;">
                                                         <?= htmlspecialchars($item['url']) ?>
                                                     </div>
+                                                </td>
+                                                <td>
+                                                    <button class="btn btn-sm btn-outline-primary" onclick="showPageContent(<?= $item['task_item_id'] ?>)" title="Pokaż treść">
+                                                        <i class="fas fa-file-alt"></i>
+                                                    </button>
                                                 </td>
                                                 <td>
                                                     <?php
@@ -323,13 +329,50 @@ $queue_items = $stmt->fetchAll();
             </div>
         </div>
     </div>
-    
+
+    <!-- Modal treści strony -->
+    <div class="modal fade" id="pageContentModal" tabindex="-1">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Treść strony</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <pre id="pageContentBody" class="bg-light p-3"></pre>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Zamknij</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
     <script>
         function showError(message) {
             document.getElementById('errorContent').textContent = message;
             var modal = new bootstrap.Modal(document.getElementById('errorModal'));
             modal.show();
+        }
+
+        async function showPageContent(taskItemId) {
+            const modalEl = document.getElementById('pageContentModal');
+            const bodyEl = document.getElementById('pageContentBody');
+            bodyEl.textContent = 'Ładowanie...';
+            const modal = new bootstrap.Modal(modalEl);
+            modal.show();
+            try {
+                const response = await fetch('ajax_get_page_content.php?task_item_id=' + taskItemId);
+                const data = await response.json();
+                if (data.error) {
+                    bodyEl.textContent = data.error;
+                } else {
+                    bodyEl.textContent = data.page_content;
+                }
+            } catch (e) {
+                bodyEl.textContent = 'Błąd ładowania treści';
+            }
         }
     </script>
 </body>

--- a/ajax_get_page_content.php
+++ b/ajax_get_page_content.php
@@ -1,0 +1,32 @@
+<?php
+require_once 'auth_check.php';
+requireAdmin();
+
+header('Content-Type: application/json');
+
+if (!isset($_GET['task_item_id']) || !is_numeric($_GET['task_item_id'])) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid task item ID']);
+    exit;
+}
+
+$task_item_id = intval($_GET['task_item_id']);
+$pdo = getDbConnection();
+
+try {
+    $stmt = $pdo->prepare("SELECT page_content FROM task_items WHERE id = ?");
+    $stmt->execute([$task_item_id]);
+    $page_content = $stmt->fetchColumn();
+
+    if ($page_content === false) {
+        http_response_code(404);
+        echo json_encode(['error' => 'Content not found']);
+        exit;
+    }
+
+    echo json_encode(['page_content' => $page_content]);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+?>


### PR DESCRIPTION
## Summary
- allow admins to check fetched page text
- add modal and AJAX endpoint in admin queue for viewing page content

## Testing
- `npm run lint` *(fails: Cannot find package)*

------
https://chatgpt.com/codex/tasks/task_e_685d36024c508333b7c5f1025a1bc16f